### PR TITLE
#43/Separated classrooms to teaching/listening

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,15 +4,14 @@ import QuizTestPage from './pages/quizTestPage';
 import LeftMenuPage from './pages/leftmenuTestPage';
 import ChatTestPage from './pages/chatTestPage';
 import YoutubeTestPage from './pages/youtubeTestPage_combined';
+import LobbyPage from './pages/lobbyPage';
 
 const App = (): React.ReactElement<any, any> => {
   return (
     <>
       <div className="App">
         <ChakraProvider>
-          {YoutubeTestPage}
-          <ChatTestPage />
-          <LeftMenuPage />
+          <LobbyPage />
         </ChakraProvider>
       </div>
     </>

--- a/client/src/data/classData.ts
+++ b/client/src/data/classData.ts
@@ -5,7 +5,8 @@ const dummyClasses = [
     title: 'CS330',
     subTitle: 'Operating Systems',
     color: 'white',
-    backgroundColor: 'black'
+    backgroundColor: 'black',
+    memberType: 'Instructor'
   },
   {
     id: 1,
@@ -13,7 +14,8 @@ const dummyClasses = [
     title: 'CS330',
     subTitle: 'Operating Systems',
     color: 'gray.50',
-    backgroundColor: 'green.600'
+    backgroundColor: 'green.600',
+    memberType: 'Participant'
   },
   {
     id: 2,
@@ -21,7 +23,8 @@ const dummyClasses = [
     title: 'CS330',
     subTitle: 'Operating Systems',
     color: 'black',
-    backgroundColor: 'white'
+    backgroundColor: 'white',
+    memberType: 'Participant'
   },
   {
     id: 3,
@@ -29,7 +32,8 @@ const dummyClasses = [
     title: 'CS330',
     subTitle: 'Operating Systems',
     color: 'teal.400',
-    backgroundColor: 'black'
+    backgroundColor: 'black',
+    memberType: 'Participant'
   },
   {
     id: 4,
@@ -37,7 +41,8 @@ const dummyClasses = [
     title: 'CS330',
     subTitle: 'Operating Systems',
     color: 'white',
-    backgroundColor: 'blue.500'
+    backgroundColor: 'blue.500',
+    memberType: 'Instructor'
   },
   {
     id: 5,
@@ -45,7 +50,8 @@ const dummyClasses = [
     title: 'CS330',
     subTitle: 'Operating Systems',
     color: 'yellow.50',
-    backgroundColor: 'blue.500'
+    backgroundColor: 'blue.500',
+    memberType: 'Participant'
   }
 ];
 

--- a/client/src/pages/lobbyPage.tsx
+++ b/client/src/pages/lobbyPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconButton, useDisclosure } from '@chakra-ui/react';
+import { IconButton, useDisclosure, Heading } from '@chakra-ui/react';
 import { useBreakpointValue } from '@chakra-ui/media-query';
 
 import { AddIcon } from '@chakra-ui/icons';
@@ -21,6 +21,14 @@ const LobbyPage = () => {
   });
   const { isOpen, onOpen, onClose } = useDisclosure();
 
+  // -- 🐛 Call DB API to get joined classroom data --
+  const instructorClassData = classData.filter(
+    (elem, index) => elem.memberType === 'Instructor'
+  );
+  const participantClassData = classData.filter(
+    (elem, index) => elem.memberType === 'Participant'
+  );
+
   return (
     <>
       <Header
@@ -30,8 +38,34 @@ const LobbyPage = () => {
         headingSize="lg"
         p={8}
       />
+
+      <br />
+
+      <Heading size="lg" pl="30px">
+        Teaching lectures
+      </Heading>
       <LobbyContent col={col}>
-        {classData.map(
+        {instructorClassData.map(
+          ({ id, imgSrc, title, subTitle, color, backgroundColor }) => (
+            <ClassCard
+              key={id}
+              imgSrc={imgSrc}
+              title={title}
+              subTitle={subTitle}
+              color={color}
+              backgroundColor={backgroundColor}
+            />
+          )
+        )}
+      </LobbyContent>
+
+      <br />
+
+      <Heading size="lg" pl="30px">
+        Listening lectures
+      </Heading>
+      <LobbyContent col={col}>
+        {participantClassData.map(
           ({ id, imgSrc, title, subTitle, color, backgroundColor }) => (
             <ClassCard
               key={id}
@@ -54,7 +88,6 @@ const LobbyPage = () => {
         icon={<AddIcon />}
         onClick={onOpen}
       />
-
       <AddClassModal onClose={onClose} isOpen={isOpen} />
     </>
   );


### PR DESCRIPTION
## 개요
#43 해결을 위해, 로비 페이지 컴포넌트 `client/src/pages/lobbyPage.tsx`를 수정했습니다.

현재 내가 구독중인 classroom 정보를 받아와서, memberType에 따라 윗단에 보여줄지, 아랫단에 보여줄지 결정합니다.

---
현재 사용중인 dummy 데이터 형태 - `memberType`이 꼭 들어가야 함.
```JS
const dummyClasses = [
  {
    id: 0,
    imgSrc: 'https://bit.ly/2Z4KKcF',
    title: 'CS330',
    subTitle: 'Operating Systems',
    color: 'white',
    backgroundColor: 'black',
    memberType: 'Instructor'
  },
  {
    id: 1,
    imgSrc: 'https://bit.ly/2Z4KKcF',
    title: 'CS330',
    subTitle: 'Operating Systems',
    color: 'gray.50',
    backgroundColor: 'green.600',
    memberType: 'Participant'
  },
  ...
];
```

`Get Class List` [API 계획](https://github.com/CS492-FE-Dev-Team-Project/FE-Dev-Client/issues/38#issuecomment-974792773)에도 `memberType` 포함되어있기에, 문제 없을 듯

---

### 완성 화면
![image](https://user-images.githubusercontent.com/39735858/142894840-ead3bd7b-1a99-4047-8c08-d0539719f69e.png)
