### PR TITLE
Integrate classroompage routing#41

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,19 @@
-import { ChakraProvider } from '@chakra-ui/react';
 import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import LoginModal from './components/loginModal';
 import ClassPage from './pages/classPage';
+import LobbyPage from './pages/lobbyPage';
 
 const App = (): React.ReactElement<any, any> => {
   return (
     <div className="App">
-      <ChakraProvider>
-        <ClassPage />
-      </ChakraProvider>
+      <LoginModal />
+      <Router>
+        <Routes>
+          <Route path="/" element={<LobbyPage />} />
+          <Route path="class/:id" element={<ClassPage />} />
+        </Routes>
+      </Router>
     </div>
   );
 };

--- a/client/src/components/lobbyPage/classCard.tsx
+++ b/client/src/components/lobbyPage/classCard.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Box, Image } from '@chakra-ui/react';
+import { Box, Image, Flex } from '@chakra-ui/react';
 
 interface ClassCardProps {
-  imgSrc: string;
+  imgSrc?: string;
   title: string;
   subTitle: string;
   color: string;
@@ -26,24 +26,30 @@ const ClassCard = ({
       boxShadow="0 0 1px rgba(0,0,0,1)"
       _hover={{ cursor: 'pointer', boxShadow: '0 0 3px rgba(0,0,0,1)' }}
     >
-      <Image src={imgSrc} alt="Sample Image" />
+      {imgSrc && <Image src={imgSrc} alt="Sample Image" />}
 
-      <Box
+      <Flex
         p={4}
         w="full"
-        h="40%"
+        h={imgSrc === undefined ? '100%' : '40%'}
         position="absolute"
         bottom={0}
         backgroundColor={backgroundColor}
         color={color}
       >
-        <Box pl={3} fontSize={20} fontWeight="bold" display="inline">
-          {`${title} | `}
+        <Box
+          pl={3}
+          fontSize={20}
+          fontWeight="bold"
+          display="inline"
+          marginTop="auto"
+        >
+          {`${title}   `}
         </Box>
-        <Box fontSize={12} fontWeight="bold" display="inline">
+        <Box fontSize={12} fontWeight="bold" display="inline" marginTop="auto">
           {`${subTitle}`}
         </Box>
-      </Box>
+      </Flex>
     </Box>
   );
 };

--- a/client/src/context/user/userProvider.tsx
+++ b/client/src/context/user/userProvider.tsx
@@ -5,7 +5,7 @@ import UserContext from './userContext';
 
 const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
   const [userName, setUserName] = useState('');
-  const [status, setUserStatus] = useState(UserLoadStatus.LOADING);
+  const [status, setUserStatus] = useState(UserLoadStatus.LOADED);
 
   useEffect(() => {
     if (status === UserLoadStatus.LOADING) {

--- a/client/src/context/user/userProvider.tsx
+++ b/client/src/context/user/userProvider.tsx
@@ -5,7 +5,7 @@ import UserContext from './userContext';
 
 const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
   const [userName, setUserName] = useState('');
-  const [status, setUserStatus] = useState(UserLoadStatus.LOADED);
+  const [status, setUserStatus] = useState(UserLoadStatus.LOADING);
 
   useEffect(() => {
     if (status === UserLoadStatus.LOADING) {

--- a/client/src/pages/classPage.tsx
+++ b/client/src/pages/classPage.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Box, Flex } from '@chakra-ui/react';
+import { useParams } from 'react-router';
 import LeftMenu from '../components/leftmenu/leftmenu';
 import menus from '../data/leftmenuData';
 import YouTube from '../components/youtube';
 import Chat from '../components/chat';
 
 const ClassPage = () => {
+  const { uuid } = useParams();
+
   const classData = {
     name: 'CS330'
   };

--- a/client/src/pages/lobbyPage.tsx
+++ b/client/src/pages/lobbyPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IconButton, useDisclosure, Heading } from '@chakra-ui/react';
 import { useBreakpointValue } from '@chakra-ui/media-query';
 import { AddIcon } from '@chakra-ui/icons';
+import { Link } from 'react-router-dom';
 
 import AddClassModal from '../components/lobbyPage/classAddModal';
 import LobbyContent from '../components/lobbyPage/lobbyContent';
@@ -42,14 +43,14 @@ const LobbyPage = () => {
         {classes
           .filter(({ memberType }) => memberType === MemberType.INSTRUCTOR)
           .map(({ uuid, title, subtitle }) => (
-            <ClassCard
-              key={uuid}
-              imgSrc="imgSrc"
-              title={title}
-              subTitle={subtitle}
-              color="black"
-              backgroundColor="white"
-            />
+            <Link to={`/class/${uuid}`} key={uuid}>
+              <ClassCard
+                title={title}
+                subTitle={subtitle}
+                color="white"
+                backgroundColor="black"
+              />
+            </Link>
           ))}
       </LobbyContent>
 
@@ -62,14 +63,15 @@ const LobbyPage = () => {
         {classes
           .filter(({ memberType }) => memberType === MemberType.STUDENT)
           .map(({ uuid, title, subtitle }) => (
-            <ClassCard
-              key={uuid}
-              imgSrc="imgSrc"
-              title={title}
-              subTitle={subtitle}
-              color="black"
-              backgroundColor="white"
-            />
+            <Link to={`/class/${uuid}`} key={uuid}>
+              <ClassCard
+                imgSrc="a"
+                title={title}
+                subTitle={subtitle}
+                color="white"
+                backgroundColor="black"
+              />
+            </Link>
           ))}
       </LobbyContent>
       <IconButton


### PR DESCRIPTION
## 개요
상현님께서 만들어주신 `ClassroomPage`(#63)를 저희 라우팅 체계에 통합시키고, 로비에서 ClassCard를 누르면 해당 반으로 이동하도록 만들었습니다

## 구현 과정

아래와 같이 `class/:id`가 path일 때 해당 id를 가진 ClassPage로 가도록 만들었습니다.
```js
// client/src/App.tsx
<Router>
  <Routes>
    <Route path="/" element={<LobbyPage />} />
    <Route path="class/:id" element={<ClassPage />} />
  </Routes>
</Router>
```

로비페이지에서 ClassCard들을 만들 때 아래처럼 링크 컴포넌트 하위에 ClassCard를 두어서 클릭 시 해당 `class/uuid`로 라우팅되도록 했습니다.
```js
classes
  .filter(({ memberType }) => memberType === MemberType.INSTRUCTOR)
  .map(({ uuid, title, subtitle }) => (
    <Link to={`/class/${uuid}`} key={uuid}> // 링크
      <ClassCard
        title={title}
        subTitle={subtitle}
        color="white"
        backgroundColor="black"
      />
    </Link>
  ))
```


