### PR TITLE
#51/Add yarn prebuild:server for only building frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "prepare": "husky install",
     "build:client": "cd client && yarn build",
     "clean": "rm -rf ./server/client && mkdir ./server/client && cd server && yarn down",
-    "build:server": "yarn build:client && cp -r ./client/build/* ./server/client && cd server && yarn build",
+    "build:server": "prebuild:server && cd server && yarn build",
     "run:server": "cd server && yarn up",
-    "build:run": "yarn build:server && yarn run:server"
+    "build:run": "yarn build:server && yarn run:server",
+    "prebuild:server":"yarn build:client && cp -r ./client/build/* ./server/client"
   },
   "devDependencies": {
     "husky": "^7.0.0"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     restart: always
     volumes:
       - ./src:/home/node/app/src
+      - ./client:/home/node/app/client
     container_name: cs492c-api-server
     expose:
       - 5000


### PR DESCRIPTION
일단 임시 방편으로 `yarn prebuild:server` 명령어를 통해 전체 빌드가 아닌 프론트엔드 빌드만 따로 할 수 있도록 만들었습니다.

명령어를 정리하자면,
1. `yarn build:run`: 프론트/백엔드 모두 포함한 도커 이미지 빌드
2. `yarn prebuild:server`: 프론트엔드만 빌드 후 컨테이너에 빌드된 웹페이지 파일 바꿔치기해줌
3. `yarn clean`: 도커 이미지, 컨테이너, 네트워크 모두 삭제 (* 볼륨은 삭제 안하므로 DB는 남아있음)