### PR TITLE
#64/class card 디자인 변경

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-scripts": "4.0.3",
     "react-youtube": "^7.13.1",
     "socket.io-client": "^4.3.2",
+    "string-to-color": "^2.2.2",
     "styled-components": "^5.3.3",
     "typescript": "^4.1.0",
     "web-vitals": "^0.2.4",

--- a/client/src/components/lobbyPage/classCard.tsx
+++ b/client/src/components/lobbyPage/classCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Image, Flex } from '@chakra-ui/react';
+import stc from 'string-to-color';
 
 interface ClassCardProps {
   imgSrc?: string;
@@ -16,37 +17,44 @@ const ClassCard = ({
   color,
   backgroundColor
 }: ClassCardProps) => {
+  const classColor = stc({ title });
+  const regexColor = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+    classColor
+  );
+  const r = regexColor ? parseInt(regexColor[1], 16) : 0;
+  const g = regexColor ? parseInt(regexColor[2], 16) : 0;
+  const b = regexColor ? parseInt(regexColor[3], 16) : 0;
+  const isDark = r + g + b < 127 * 3;
+
   return (
     <Box
-      w={300}
-      h={200}
+      w={240}
+      h={150}
       overflow="hidden"
       position="relative"
       borderRadius="30px"
-      boxShadow="0 0 1px rgba(0,0,0,1)"
+      color={isDark ? 'white' : 'black'}
       _hover={{ cursor: 'pointer', boxShadow: '0 0 3px rgba(0,0,0,1)' }}
     >
-      {imgSrc && <Image src={imgSrc} alt="Sample Image" />}
-
       <Flex
         p={4}
         w="full"
-        h={imgSrc === undefined ? '100%' : '40%'}
+        h="100%"
         position="absolute"
         bottom={0}
-        backgroundColor={backgroundColor}
-        color={color}
+        backgroundColor={classColor}
+        direction="column"
       >
         <Box
-          pl={3}
-          fontSize={20}
+          pl="5px"
+          fontSize={40}
           fontWeight="bold"
           display="inline"
           marginTop="auto"
         >
           {`${title}   `}
         </Box>
-        <Box fontSize={12} fontWeight="bold" display="inline" marginTop="auto">
+        <Box pl="5px" fontSize={20} fontWeight="bold" display="inline">
           {`${subTitle}`}
         </Box>
       </Flex>

--- a/client/src/components/lobbyPage/classCard.tsx
+++ b/client/src/components/lobbyPage/classCard.tsx
@@ -28,7 +28,6 @@ const ClassCard = ({
 
   return (
     <Box
-      w={240}
       h={150}
       overflow="hidden"
       position="relative"

--- a/client/src/components/lobbyPage/lobbyContent.tsx
+++ b/client/src/components/lobbyPage/lobbyContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid } from '@chakra-ui/react';
+import { SimpleGrid } from '@chakra-ui/react';
 
 interface LobbyContentProps {
   col: string | undefined;
@@ -11,9 +11,9 @@ const LobbyContent = ({
 }: React.PropsWithChildren<LobbyContentProps>) => {
   return (
     <>
-      <Grid templateColumns={`repeat(${col ?? 5}, 1fr)`} p={5} gap={8}>
+      <SimpleGrid minChildWidth="260px" spacing={8} p={5}>
         {children}
-      </Grid>
+      </SimpleGrid>
     </>
   );
 };

--- a/client/src/components/lobbyPage/lobbyContent.tsx
+++ b/client/src/components/lobbyPage/lobbyContent.tsx
@@ -11,7 +11,7 @@ const LobbyContent = ({
 }: React.PropsWithChildren<LobbyContentProps>) => {
   return (
     <>
-      <Grid templateColumns={`repeat(${col ?? 4}, 1fr)`} p={5} gap={8}>
+      <Grid templateColumns={`repeat(${col ?? 5}, 1fr)`} p={5} gap={8}>
         {children}
       </Grid>
     </>

--- a/client/src/pages/lobbyPage.tsx
+++ b/client/src/pages/lobbyPage.tsx
@@ -84,8 +84,8 @@ const LobbyPage = () => {
       </LobbyContent>
       <IconButton
         position="fixed"
-        right="100px"
-        bottom="100px"
+        right="5%"
+        bottom="10%"
         size="lg"
         aria-label="Add Classroom"
         colorScheme="green"


### PR DESCRIPTION
- #64 

### 1. Lobby Page의 class card 디자인을 변경
디자인적 이슈라 따로 이슈를 만들지 않고 기존 디자인 이슈 브랜치에서 작업했습니다.
기존 클래스 카드의 경우 이미지를 넣는 방식이 유저에게 번거롭기 때문에 자동으로 색을 입히는 방식으로 구현해보았습니다.

- string-to-color 라이브러리를 이용하여 과목별 색상 자동 설정
- 색상 밝기에 따른 폰트 색상 자동 설정
- 창 크기에 따른 Grid 배열 더 깔끔하게 변경

![image](https://user-images.githubusercontent.com/84287503/144105098-046d3e20-4113-44a0-b853-eb4ae0785540.png)

기존 디자인과는 많이 다르기 때문에 기존 디자인대로 진행하는게 나을지 comment 남겨주시면 감사하겠습니다.
