### PR TITLE
#94/Add userId return from meRoute

### DIFF
--- a/client/src/components/chat.tsx
+++ b/client/src/components/chat.tsx
@@ -7,6 +7,7 @@ import Header from './common/Header';
 
 import { MarkerType } from '../types';
 
+import useMe from '../hooks/useMe';
 import { useSocket } from '../context/socket';
 import dummyMessages from '../data/chatMessages'; // 🐛 Dummy message - call DB API to get real data
 
@@ -38,6 +39,7 @@ const Chat = ({ hasHeader, customHeader = '' }: ChatProps) => {
   const [messages, setMessages] = useState<Array<Message>>([]);
   const [chatMode, setChatMode] = useState<ChatMode>(ChatMode.LIVE);
   const currentMarkerId = useRef<number>(-1);
+  const { userId, userName: currentUserName } = useMe();
 
   // Set Chat header title
   const pickHeader = ['Question', 'Quiz', 'Notice', 'Discussion'];

--- a/client/src/context/user/userContext.tsx
+++ b/client/src/context/user/userContext.tsx
@@ -2,11 +2,13 @@ import { createContext } from 'react';
 import { UserLoadStatus } from '../../types';
 
 interface UserContextInterface {
+  userId: number;
   userName: string;
   status: UserLoadStatus;
 }
 
 const UserContext = createContext<UserContextInterface>({
+  userId: 0,
   userName: '',
   status: UserLoadStatus.LOADED
 });

--- a/client/src/context/user/userProvider.tsx
+++ b/client/src/context/user/userProvider.tsx
@@ -4,6 +4,7 @@ import { UserLoadStatus } from '../../types';
 import UserContext from './userContext';
 
 const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
+  const [userId, setUserId] = useState(0);
   const [userName, setUserName] = useState('');
   const [status, setUserStatus] = useState(UserLoadStatus.LOADING);
 
@@ -18,6 +19,7 @@ const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
             setUserStatus(UserLoadStatus.NOTLOADED);
           } else if (r.status === 200) {
             console.log('Logged IN');
+            setUserId(r.userId);
             setUserName(r.userName);
             setUserStatus(UserLoadStatus.LOADED);
           }
@@ -27,7 +29,7 @@ const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
   }, []);
 
   return (
-    <UserContext.Provider value={{ userName, status }}>
+    <UserContext.Provider value={{ userId, userName, status }}>
       {children}
     </UserContext.Provider>
   );

--- a/client/src/hooks/useMe.tsx
+++ b/client/src/hooks/useMe.tsx
@@ -2,9 +2,9 @@ import { useContext } from 'react';
 import UserContext from '../context/user/userContext';
 
 const useMe = () => {
-  const { status, userName } = useContext(UserContext);
+  const { status, userId, userName } = useContext(UserContext);
 
-  return { status, userName };
+  return { status, userId, userName };
 };
 
 export default useMe;

--- a/server/src/routes/meRoute/index.ts
+++ b/server/src/routes/meRoute/index.ts
@@ -6,7 +6,8 @@ export default (app: Router) => {
   app.use('/me', meRouter);
 
   meRouter.get('/', authenticateUser, (req, res) => {
+    const userId = req.user?.id;
     const userName = req.user?.userName;
-    res.json({ userName, status: 200 });
+    res.json({ userId, userName, status: 200 });
   });
 };


### PR DESCRIPTION
## 개요
클라이언트 쪽에서 자신의 userId를 받아올 수 있도록,
클라이언트 훅 `useMe`, 서버 라우팅 엔드포인트 `meRoute` 수정.

## Usage
```ts
// client/src/components/chat.tsx
const { userId, userName: currentUserName } = useMe();
```
