### PR TITLE
Separate class lecture pages#106

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,25 +3,28 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import LoginModal from './components/loginModal';
 import { SocketProvider } from './context/socket';
 import ClassPage from './pages/classPage';
+import LecturePage from './pages/lecturePage';
 import LobbyPage from './pages/lobbyPage';
 
 const App = (): React.ReactElement<any, any> => {
   return (
     <div className="App">
-      <LoginModal />
-      <Router>
-        <Routes>
-          <Route path="/" element={<LobbyPage />} />
-          <Route
-            path="class/:classUuid/:memberType"
-            element={
-              <SocketProvider url="http://localhost:5000/">
-                <ClassPage />
-              </SocketProvider>
-            }
-          />
-        </Routes>
-      </Router>
+      <SocketProvider url="http://localhost:5000/">
+        <LoginModal />
+        <Router>
+          <Routes>
+            <Route path="/" element={<LobbyPage />} />
+            <Route
+              path="class/:classUuid/:memberType"
+              element={<ClassPage />}
+            />
+            <Route
+              path="class/:classUuid/:memberType/:lectureId"
+              element={<LecturePage />}
+            />
+          </Routes>
+        </Router>
+      </SocketProvider>
     </div>
   );
 };

--- a/client/src/pages/classPage.tsx
+++ b/client/src/pages/classPage.tsx
@@ -1,17 +1,45 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Flex } from '@chakra-ui/react';
-import { useLocation, useParams } from 'react-router';
+import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
 import LeftMenu from '../components/leftmenu/leftmenu';
 import menus from '../data/leftmenuData';
-import YouTube from '../components/youtube';
 import Chat from '../components/chat';
 import FloatConnectionStatus from '../components/floatConnectionStatus';
-import useMe from '../hooks/useMe';
-import { Class, MemberType } from '../types';
+import { Lecture } from '../types';
+import { useSocket } from '../context/socket';
+
+// 🐛 나중에 lecture grid로 대체
+import ClassCard from '../components/lobbyPage/classCard';
 
 const ClassPage = () => {
-  const { status, userName } = useMe();
   const { classUuid, memberType } = useParams();
+  const { socket, connected } = useSocket();
+  const [lectureList, setLectureList] = useState<Lecture[]>([]);
+
+  useEffect(() => {
+    // get all lectures in the classroom
+    socket?.on('GetLectures', lectureArr => {
+      setLectureList(lectureArr);
+    });
+
+    const payload = JSON.stringify({ classUuid });
+    socket?.emit('GetLectures', payload);
+  }, [connected]);
+
+  const sampleLectureList = [
+    { lectureId: 1 },
+    { lectureId: 2 },
+    { lectureId: 3 }
+  ];
+
+  // 🐛 대기 화면 - lecture grid로 대체
+  const imgURL =
+    'https://previews.123rf.com/images/sevenozz/sevenozz1812/sevenozz181200056/127054720-vintage-tv-test-screen-please-stand-by-television-calibration-pattern.jpg';
+  const coverStyles = {
+    backgroundImage: `url(${imgURL})`,
+    backgroundSize: '100% 100%'
+  };
 
   return (
     <>
@@ -19,15 +47,25 @@ const ClassPage = () => {
       <Flex>
         <LeftMenu menus={menus} />
         <Box w="8px" h="100vh" />
-        <Box w="100%" h="100vh">
-          <YouTube
-            userName={userName}
-            memberType={(memberType ?? MemberType.STUDENT) as MemberType}
-            room={classUuid ?? 'uuid error'}
-            videoId="j1_5ttGRzFs"
-            width="100%"
-            height="100%"
-          />
+        <Box w="100%" h="100vh" style={coverStyles}>
+          {/* 상현님이 구현해주실 classPage lecture grid 이곳에 - Issue #99 */}
+          {
+            /* 🐛 lectureList로 바꾸기 */ sampleLectureList.map(
+              ({ lectureId }) => (
+                <Link
+                  to={`/class/${classUuid}/${memberType}/${lectureId}`}
+                  key={lectureId}
+                >
+                  <ClassCard
+                    title={`Lecture${lectureId}`}
+                    subTitle={`Test${lectureId}`}
+                    color="white"
+                    backgroundColor="black"
+                  />
+                </Link>
+              )
+            )
+          }
         </Box>
         <Chat hasHeader />
       </Flex>

--- a/client/src/pages/lecturePage.tsx
+++ b/client/src/pages/lecturePage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Flex } from '@chakra-ui/react';
+import { useParams } from 'react-router';
+import LeftMenu from '../components/leftmenu/leftmenu';
+import menus from '../data/leftmenuData';
+import YouTube from '../components/youtube';
+import Chat from '../components/chat';
+import FloatConnectionStatus from '../components/floatConnectionStatus';
+import useMe from '../hooks/useMe';
+import { MemberType } from '../types';
+
+const ClassPage = () => {
+  const { userName } = useMe();
+  const { classUuid, memberType, lectureId } = useParams();
+
+  return (
+    <>
+      <FloatConnectionStatus />
+      <Flex>
+        <LeftMenu menus={menus} />
+        <Box w="8px" h="100vh" />
+        <Box w="100%" h="100vh">
+          <YouTube
+            userName={userName}
+            memberType={(memberType ?? MemberType.STUDENT) as MemberType}
+            room={classUuid ?? 'uuid error'}
+            videoId="j1_5ttGRzFs"
+            width="100%"
+            height="100%"
+          />
+        </Box>
+        <Chat hasHeader />
+      </Flex>
+    </>
+  );
+};
+
+export default ClassPage;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -5,6 +5,13 @@ export interface Class {
   memberType: MemberType;
 }
 
+export interface Lecture {
+  id: number;
+  lectureDate: string;
+  lectureName: string;
+  playlist: string;
+}
+
 export enum MemberType {
   INSTRUCTOR = 'instructor',
   STUDENT = 'student'


### PR DESCRIPTION
### lobbyPage.tsx - 변경사항 없음
`http://localhost:5000/`

![image](https://user-images.githubusercontent.com/39735858/144271351-67e57af0-f120-421b-b86d-9a5dbf92eee5.png)

<br>

### classPage.tsx - 새로 만듦
`http://localhost:5000/class/4ae24be4-7240-4884-8981-01d66b8ddb85/instructor`

일단 `sampleLectureList`와 `ClassCard` 이용해서 lecture list를 중앙에 표시했습니다.
📝 나중에 API를 통해 lecture list 받은 뒤, 상현님이 구현하실 lecture grid 이용해서 표시하겠습니다.

![image](https://user-images.githubusercontent.com/39735858/144271389-c65fb4df-44b7-41e4-af62-d7e7822235d8.png)

<br>

### lecturePage.tsx - 이전의 classPage
`http://localhost:5000/class/4ae24be4-7240-4884-8981-01d66b8ddb85/instructor/1`

![image](https://user-images.githubusercontent.com/39735858/144271512-24f7ccb7-0373-4ed1-b532-3767a762d926.png)


## 특이사항 (문제점?)

`<Routes>` 바로 아래에 `<SocketProvider>`를 넣을 수 없어서, ClassPage와 LecturePage만 커버하는 SocketProvider 설치가 불가능합니다. 그래서 그냥 가장 바깥에 두었는데, 문제 있을지 모르겠습니다. (일단 작동은 잘 됩니다)

```TS
// App.tsx
const App = (): React.ReactElement<any, any> => {
  return (
    <div className="App">
      <SocketProvider url="http://localhost:5000/">
        <LoginModal />
        <Router>
          <Routes>
            <Route path="/" element={<LobbyPage />} />
            <Route
              path="class/:classUuid/:memberType"
              element={<ClassPage />}
            />
            <Route
              path="class/:classUuid/:memberType/:lectureId"
              element={<LecturePage />}
            />
          </Routes>
        </Router>
      </SocketProvider>
    </div>
  );
};
```