### PR TITLE
#66/createlecture

### DIFF
--- a/client/src/components/lobbyPage/AddLecture.tsx
+++ b/client/src/components/lobbyPage/AddLecture.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import {
+  IconButton,
+  useDisclosure,
+  Heading,
+  Button,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Center,
+  Stack
+} from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+
+import ClassTitle from './createLecture/classTitle';
+import ClassNotice from './createLecture/classnotice';
+import ClassTime from './createLecture/classTime';
+import AddPlayList from './createLecture/addplaylist';
+import AddQuizModal from './createLecture/addquizmodal';
+
+const AddLecturePage = () => {
+  const {
+    isOpen: isAddopen,
+    onOpen: onAddopen,
+    onClose: onAddclose
+  } = useDisclosure();
+  const [Lecturetitle, setLecturetitle] = React.useState('');
+  const [Lecturemonth, setLecturemonth] = React.useState('');
+  const [Lectureday, setLectureday] = React.useState('');
+  const [Lecturehour, setLecturehour] = React.useState('');
+  const [Lecturemin, setLecturemin] = React.useState('');
+  const [Lecturenotice, setLecturenotice] = React.useState('');
+  const [Lecturelink, setLecturelink] = React.useState('');
+  const [Lecturequiztime, setLecturequiztime] = React.useState('');
+  const [Lectureproblem, setLectureproblem] = React.useState('');
+  const [Lectureanswer, setLectureanswer] = React.useState('');
+  const [Qurrentnumber, setQurrentnumber] = React.useState('');
+  const [Lecturequizhead, setLecturequizhead] = React.useState([
+    {
+      id: 0,
+      playlist: Lecturelink,
+      link: 'Lecture Link',
+      title: 'Video Title',
+      quiztime: 'Lecture Quiz Time',
+      problem: 'Lecture Problem',
+      answer: 'Lecture Answer',
+      mark: 0
+    }
+  ]);
+  const [Lecturequizlist, setLecturequizlist] = React.useState([
+    {
+      id: 1,
+      playlist: Lecturelink,
+      link: ' ',
+      title: ' ',
+      quiztime: ' ',
+      problem: ' ',
+      answer: ' ',
+      mark: 0
+    }
+  ]);
+  const onChangeCreate = () => {
+    setLecturequizlist(Lecturequizlist.filter((item: any) => item.mark !== 0));
+  };
+  const onChangeLecturetitle = (e: any) => {
+    setLecturetitle(e.target.value);
+  };
+  const onChangeLecturemonth = (e: any) => {
+    setLecturemonth(e.target.value);
+  };
+  const onChangeLectureday = (e: any) => {
+    setLectureday(e.target.value);
+  };
+  const onChangeLecturehour = (e: any) => {
+    setLecturehour(e.target.value);
+  };
+  const onChangeLecturemin = (e: any) => {
+    setLecturemin(e.target.value);
+  };
+  const onChangeLecturenotice = (e: any) => {
+    setLecturenotice(e.target.value);
+  };
+  const onChangeLectureproblem = (e: any) => {
+    setLectureproblem(e.target.value);
+  };
+  const onChangeLectureanswer = (e: any) => {
+    setLectureanswer(e.target.value);
+  };
+  const onChangeLecturequiztime = (e: any) => {
+    setLecturequiztime(e.target.value);
+  };
+  const onChangeLecturelink = (e: any) => {
+    setLecturelink(e.target.value);
+  };
+  const onClickRemove = (e: any) => {
+    removequiz(e.target.id);
+  };
+  const removequiz = (i: number) => {
+    const tempquizlist = [...Lecturequizlist];
+    tempquizlist[i - 1].quiztime = ' ';
+    tempquizlist[i - 1].problem = ' ';
+    tempquizlist[i - 1].answer = ' ';
+    tempquizlist[i - 1].mark = 0;
+    setLecturequizlist(tempquizlist);
+  };
+  const showQuiz = Lecturequizlist.map((item: any) => {
+    return (
+      <Table variant="simple" size="sm">
+        <Tbody>
+          <Tr align="left">
+            <Th align="left" width="5%">
+              {item.id}
+            </Th>
+            <Th align="left" width="15%">
+              {item.title}
+            </Th>
+            <Th align="left" width="10%">
+              {item.quiztime}
+            </Th>
+            <Th align="left" width="15%">
+              {item.problem}
+            </Th>
+            <Th align="left" width="5%">
+              {item.answer}
+            </Th>
+            <Th align="center" width="5%">
+              <AddQuizModal
+                id={item.id}
+                isAddopen={isAddopen}
+                onAddopen={onAddopen}
+                onAddclose={onAddclose}
+                onChangeLectureproblem={onChangeLectureproblem}
+                onChangeLectureanswer={onChangeLectureanswer}
+                onChangeLecturequiztime={onChangeLecturequiztime}
+                Lectureproblem={Lectureproblem}
+                Lectureanswer={Lectureanswer}
+                Lecturequiztime={Lecturequiztime}
+                setQurrentnumber={setQurrentnumber}
+                Lecturequizlist={Lecturequizlist}
+                Qurrentnumber={Qurrentnumber}
+                setLecturequizlist={setLecturequizlist}
+              />
+            </Th>
+            <Th align="center" width="5%">
+              <IconButton
+                id={item.id}
+                aria-label="Add to friends"
+                icon={<DeleteIcon />}
+                onClick={onClickRemove}
+              />
+            </Th>
+          </Tr>
+        </Tbody>
+      </Table>
+    );
+  });
+  const showQuizhead = Lecturequizhead.map((item: any) => {
+    return (
+      <Table variant="simple">
+        <Thead>
+          <Tr align="left">
+            <Th align="left" width="5%">
+              {item.id}
+            </Th>
+            <Th align="left" width="15%">
+              {item.title}
+            </Th>
+            <Th align="left" width="10%">
+              {item.quiztime}
+            </Th>
+            <Th align="left" width="15%">
+              {item.problem}
+            </Th>
+            <Th align="left" width="5%">
+              {item.answer}
+            </Th>
+            <Th align="center" width="5%">
+              Add
+            </Th>
+            <Th align="center" width="5%">
+              Remove
+            </Th>
+          </Tr>
+        </Thead>
+      </Table>
+    );
+  });
+  return (
+    <Stack spacing="24px">
+      <Center bg="black" h="100px" color="white" fontSize="2xl">
+        Create Lecture
+      </Center>
+      <ClassTitle onChangeLecturetitle={onChangeLecturetitle} />
+      <ClassNotice onChangeLecturenotice={onChangeLecturenotice} />
+      <ClassTime
+        onChangeLecturemonth={onChangeLecturemonth}
+        onChangeLectureday={onChangeLectureday}
+        onChangeLecturehour={onChangeLecturehour}
+        onChangeLecturemin={onChangeLecturemin}
+      />
+      <AddPlayList
+        Lecturequizlist={Lecturequizlist}
+        onChangeLecturelink={onChangeLecturelink}
+        Lecturelink={Lecturelink}
+        setLecturequizlist={setLecturequizlist}
+      />
+      <Heading size="md" pl="30px">
+        Quiz List
+      </Heading>
+      <ol>{showQuizhead}</ol>
+      <ol>{showQuiz}</ol>
+      <Button colorScheme="blue" mr={3} onClick={onChangeCreate}>
+        Create Lecture
+      </Button>
+    </Stack>
+  );
+};
+
+export default AddLecturePage;

--- a/client/src/components/lobbyPage/createLecture/addplaylist.tsx
+++ b/client/src/components/lobbyPage/createLecture/addplaylist.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Heading, Text, Stack, HStack, Input, Button } from '@chakra-ui/react';
+
+import axios from 'axios';
+
+const AddPlayList = ({
+  onChangeLecturelink,
+  Lecturelink,
+  setLecturequizlist
+}: any) => {
+  let Youtubelist = [
+    {
+      id: 1,
+      link: '',
+      title: '',
+      quiztime: '',
+      problem: '',
+      answer: ''
+    }
+  ];
+  const getPlayListItems = async (playlistID: any) => {
+    const result = await axios.get(
+      `https://www.googleapis.com/youtube/v3/playlistItems`,
+      {
+        params: {
+          part: 'id,snippet',
+          maxResults: 10,
+          playlistId: playlistID,
+          key: process.env.REACT_APP_YOUTUBE_API_KEY
+        }
+      }
+    );
+    return result.data;
+  };
+  const onClickAdd = () => {
+    getPlayListItems(Lecturelink).then(data => {
+      let i = 1;
+      data.items.forEach((element: any) => {
+        if (i === 1) {
+          const newquiz = [
+            {
+              id: 1 + 1 - 1,
+              link: element.snippet.resourceId.videoId,
+              title: element.snippet.title,
+              quiztime: ' ',
+              problem: ' ',
+              answer: ' ',
+              mark: 0
+            }
+          ];
+          Youtubelist = newquiz;
+          i += 1;
+        } else {
+          const newquiz = {
+            id: i,
+            link: element.snippet.resourceId.videoId,
+            title: element.snippet.title,
+            quiztime: ' ',
+            problem: ' ',
+            answer: ' ',
+            mark: 0
+          };
+          Youtubelist.push(newquiz);
+          i += 1;
+        }
+      });
+      setLecturequizlist(Youtubelist);
+    });
+  };
+  const onClickRemove = () => {
+    setLecturequizlist([
+      {
+        id: 1,
+        link: ' ',
+        quiztime: ' ',
+        problem: ' ',
+        answer: ' '
+      }
+    ]);
+  };
+  return (
+    <Stack spacing="24px">
+      <Heading size="md" pl="30px">
+        Youtube playlist
+      </Heading>
+      <Text size="sm" pl="30px">
+        Input Youtube playlist.
+        <br />
+        For
+        https://www.youtube.com/playlist?list=PLFt2h1jjxKxwQAQr6Dv5kYP4Uu5cGX1iH
+        <br />
+        Just input PLFt2h1jjxKxwQAQr6Dv5kYP4Uu5cGX1iH
+      </Text>
+      <HStack spacing="30px" pl="30px">
+        <Input
+          placeholder="Youtube Material link"
+          onChange={onChangeLecturelink}
+          focusBorderColor="black"
+          w="500px"
+        />
+        <Button colorScheme="blue" mr={3} onClick={onClickAdd}>
+          Add
+        </Button>
+        <Button colorScheme="red" mr={3} onClick={onClickRemove}>
+          Remove All
+        </Button>
+      </HStack>
+    </Stack>
+  );
+};
+
+export default AddPlayList;

--- a/client/src/components/lobbyPage/createLecture/addquizmodal.tsx
+++ b/client/src/components/lobbyPage/createLecture/addquizmodal.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Stack,
+  IconButton,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Box,
+  Input,
+  Button,
+  FormLabel,
+  Textarea
+} from '@chakra-ui/react';
+
+import { AddIcon } from '@chakra-ui/icons';
+
+const AddQuizModal = ({
+  id,
+  isAddopen,
+  onAddopen,
+  onAddclose,
+  onChangeLectureproblem,
+  onChangeLectureanswer,
+  onChangeLecturequiztime,
+  Lectureproblem,
+  Lectureanswer,
+  Lecturequiztime,
+  setQurrentnumber,
+  Lecturequizlist,
+  Qurrentnumber,
+  setLecturequizlist
+}: any) => {
+  const onAddopenwithnum = (e: any) => {
+    setQurrentnumber(e.target.id);
+    onAddopen();
+  };
+  const addquiz = () => {
+    const tempquizlist = [...Lecturequizlist];
+    tempquizlist[Qurrentnumber - 1].quiztime = Lecturequiztime;
+    tempquizlist[Qurrentnumber - 1].problem = Lectureproblem;
+    tempquizlist[Qurrentnumber - 1].answer = Lectureanswer;
+    tempquizlist[Qurrentnumber - 1].mark = 1;
+    setLecturequizlist(tempquizlist);
+    onAddclose();
+  };
+  return (
+    <Stack>
+      <IconButton
+        id={id}
+        aria-label="Add to friends"
+        icon={<AddIcon />}
+        onClick={onAddopenwithnum}
+      />
+      <Modal isOpen={isAddopen} onClose={onAddclose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Create Quiz</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Stack spacing="20px">
+              <Stack>
+                <Box>Problem Description</Box>
+                <Textarea
+                  placeholder="Description"
+                  onChange={onChangeLectureproblem}
+                  focusBorderColor="black"
+                />
+              </Stack>
+              <Stack>
+                <Box>Answer</Box>
+                <Input
+                  type="text"
+                  placeholder="Problem Answer"
+                  onChange={onChangeLectureanswer}
+                  focusBorderColor="black"
+                />
+              </Stack>
+              <Stack>
+                <Box>Quiz Open Time</Box>
+                <FormLabel>If 07:34 please enter 0734</FormLabel>
+                <Input
+                  type="text"
+                  placeholder="Quiz pop up time"
+                  onChange={onChangeLecturequiztime}
+                  focusBorderColor="black"
+                />
+              </Stack>
+            </Stack>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={addquiz}>
+              Add
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Stack>
+  );
+};
+
+export default AddQuizModal;

--- a/client/src/components/lobbyPage/createLecture/classTime.tsx
+++ b/client/src/components/lobbyPage/createLecture/classTime.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Heading, Input, FormLabel, Stack, HStack } from '@chakra-ui/react';
+
+const ClassTime = ({
+  onChangeLecturemonth,
+  onChangeLectureday,
+  onChangeLecturehour,
+  onChangeLecturemin
+}: any) => {
+  return (
+    <Stack spacing="24px">
+      <Heading size="md" pl="30px">
+        Class Time
+      </Heading>
+      <HStack pl="30px">
+        <Input
+          type="text"
+          placeholder="M"
+          onChange={onChangeLecturemonth}
+          w="50px"
+          focusBorderColor="black"
+        />
+        <FormLabel>/</FormLabel>
+        <Input
+          type="text"
+          placeholder="D"
+          onChange={onChangeLectureday}
+          w="50px"
+          focusBorderColor="black"
+        />
+        <FormLabel>/</FormLabel>
+        <Input
+          type="text"
+          placeholder="H"
+          onChange={onChangeLecturehour}
+          w="50px"
+          focusBorderColor="black"
+        />
+        <FormLabel>:</FormLabel>
+        <Input
+          type="text"
+          placeholder="M"
+          onChange={onChangeLecturemin}
+          w="50px"
+          focusBorderColor="black"
+        />
+      </HStack>
+    </Stack>
+  );
+};
+
+export default ClassTime;

--- a/client/src/components/lobbyPage/createLecture/classTitle.tsx
+++ b/client/src/components/lobbyPage/createLecture/classTitle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Heading, Input, FormControl, Stack } from '@chakra-ui/react';
+
+const ClassTitle = (onChangeLecturetitle: any) => {
+  return (
+    <Stack spacing="24px">
+      <Heading size="lg" pl="30px">
+        Class Title
+      </Heading>
+      <FormControl pl="30px">
+        <Input
+          type="text"
+          placeholder="Class Title"
+          onChange={onChangeLecturetitle}
+          w="500px"
+          focusBorderColor="black"
+        />
+      </FormControl>
+    </Stack>
+  );
+};
+
+export default ClassTitle;

--- a/client/src/components/lobbyPage/createLecture/classnotice.tsx
+++ b/client/src/components/lobbyPage/createLecture/classnotice.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Heading, FormControl, Stack, Textarea } from '@chakra-ui/react';
+
+const ClassNotice = (onChangeLecturenotice: any) => {
+  return (
+    <Stack spacing="24px">
+      <Heading size="md" pl="30px">
+        Notice
+      </Heading>
+      <FormControl pl="30px">
+        <Textarea
+          placeholder="Description"
+          onChange={onChangeLecturenotice}
+          focusBorderColor="black"
+          w="500px"
+        />
+      </FormControl>
+    </Stack>
+  );
+};
+
+export default ClassNotice;

--- a/client/src/pages/lobbyPage.tsx
+++ b/client/src/pages/lobbyPage.tsx
@@ -17,6 +17,7 @@ import Header from '../components/common/Header';
 import useClasses from '../hooks/useClasses';
 import { MemberType } from '../types';
 import LogoAsset from '../assets/logo2.svg';
+import AddLecturePage from '../components/lobbyPage/AddLecture';
 
 const LobbyPage = () => {
   const col = useBreakpointValue({
@@ -88,6 +89,7 @@ const LobbyPage = () => {
         onClick={onOpen}
       />
       <AddClassModal onClose={onClose} isOpen={isOpen} addClass={addClass} />
+      <AddLecturePage />
     </>
   );
 };


### PR DESCRIPTION
### Create Lecture page 생성

Class 안에서 Lecture page를 생성하는 페이지를 만들었습니다.

![image](https://user-images.githubusercontent.com/68766445/144387275-8876dcd4-424d-4a43-80ba-a1d95ccb5884.png)

페이지에 들어오면 다음과 같은 화면이 보입니다.
초록색 +버튼은 Class add modal로 원래는 이 페이지에 들어있지 않습니다.

Youtube의 playlist를 추가하게 되면
![image](https://user-images.githubusercontent.com/68766445/144387535-a4ce156c-8b5a-4b69-ab1a-052375aa0fac.png)
다음과 같이 list 안에 담긴 영상들이 quiz list에 나타나게 됩니다.

각 리스트 옆의 + 버튼을 누르게 되면
![image](https://user-images.githubusercontent.com/68766445/144387673-e86a26e6-9325-46d0-935d-cb93a54c7f12.png)

다음과 같은 modal 창이 나오게 되고 add를 누르면 다음과 같이 추가됩니다.

![image](https://user-images.githubusercontent.com/68766445/144387733-d8351ee0-c0fb-409a-9422-30ca057b6de6.png)


지우고 싶으면 옆의 휴지통을 누르면 사라지게 됩니다.

가장 밑의 create lecture 버튼을 누르면 퀴즈가 없는 영상은 list에서 사라지게 되고
퀴즈가 들어간 영상의 리스트만 출력을 하게 하였습니다.

![image](https://user-images.githubusercontent.com/68766445/144388040-c967694e-e388-488a-9981-bf3dec12c746.png)

이 부분은 server에 어느 정보를 전달할지에 따라서 수정을 하면 될 것 같습니다.

각각의 정보는 다음과 같은 state에 선언이 되어 있습니다.
![image](https://user-images.githubusercontent.com/68766445/144388259-11b058d9-02c6-4935-9cf9-967845df8ad2.png)

Lecturelink : playlist의 주소

![image](https://user-images.githubusercontent.com/68766445/144388352-1a349bae-638e-48b7-b0c3-9caf300ee7e5.png)

Lecturequizlist에 퀴즈와 영상 관련 정보를 다 저장하였습니다.

마지막의 
![image](https://user-images.githubusercontent.com/68766445/144388449-103392d0-cc93-4324-8c02-3c0fc9ebe495.png)

Create lecture 버튼을 누르면 실행되는 함수인데
기본 실행은 퀴즈가 담겨있지 않은 (mark로 표시) list는 다 삭제합니다. 
혹시 퀴즈가 없는 영상 리스트도 그대로 들고가고 싶다 하면 이 함수를 조금 수정하면 될 것 같습니다.



