### PR TITLE
Fix live chat bug#109

### DIFF
--- a/client/src/components/chat.tsx
+++ b/client/src/components/chat.tsx
@@ -5,11 +5,10 @@ import ChatMessage from './chatMessage';
 import ChatInput from './chatInput';
 import Header from './common/Header';
 
-import { MarkerType } from '../types';
+import { MarkerType, TextMessageResponse } from '../types';
 
 import { useSocket } from '../context/socket';
 import useMe from '../hooks/useMe';
-import dummyMessages from '../data/chatMessages'; // 🐛 Dummy message - call DB API to get real data
 
 enum ChatMode {
   Marker = 'Marker',
@@ -26,27 +25,33 @@ type ChatStatus =
 
 interface ChatProps {
   hasHeader: boolean;
-  room: string;
+  classUuid: string;
+  lectureId: number;
   customHeader?: string;
 }
 
 // 🚨 Possible duplicate with 'interface ChatMessageProps' in 'chatMessage.tsx'
 interface Message {
+  messageId: number;
   userName: string;
   message: string;
   time: string;
-  id: number;
   isMy: boolean;
 }
 
-const Chat = ({ hasHeader, room, customHeader = '' }: ChatProps) => {
+const Chat = ({
+  hasHeader,
+  classUuid,
+  lectureId,
+  customHeader = ''
+}: ChatProps) => {
   const { socket, connected } = useSocket();
-  const [messages, setMessages] = useState<Array<Message>>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
   const [chatStatus, setChatStatus] = useState<ChatStatus>({
     chatMode: ChatMode.Live
   });
   const currentMarkerId = useRef<number>(-1);
-  const { userName: currentUserName } = useMe();
+  const { id: myId, userName: myName } = useMe();
 
   // Set Chat header title
   const pickHeader = (chatStat: ChatStatus) => {
@@ -74,25 +79,28 @@ const Chat = ({ hasHeader, room, customHeader = '' }: ChatProps) => {
         // 🐛 (API) Fetch timeMarker thread messages
         currentMarkerId.current = markerId;
         // setChatMode(markerType as number);
-        setMessages(dummyMessages.slice(markerId * 3, markerId * 3 + 3));
+        // setMessages(dummyMessages.slice(markerId * 3, markerId * 3 + 3));
       }
     );
 
     // Live chat event - get live chat message
-    socket?.on('ChatTextMessage', (payload: string) => {
-      const { dateStr, textMessage, chatUserName, isMy } = JSON.parse(payload);
-
+    socket?.on('LiveChatTextMessage', ({ message, status }) => {
+      const {
+        dateStr,
+        senderId,
+        senderName,
+        text,
+        messageId
+      }: TextMessageResponse = message;
       const dateObj = new Date(dateStr);
-
-      const dummyMessageObj: Message = {
-        id: 999, // 🐛 Get rid of id?
-        userName: chatUserName,
-        message: textMessage,
+      const messageObj: Message = {
+        messageId,
+        userName: senderName,
+        message: text,
         time: `${dateObj.getHours()}:${dateObj.getMinutes()}`,
-        isMy
+        isMy: senderId === myId
       };
-
-      setMessages(arr => [...arr, dummyMessageObj]);
+      setMessages(arr => [...arr, messageObj]);
     });
   }, [connected]);
 
@@ -104,24 +112,17 @@ const Chat = ({ hasHeader, room, customHeader = '' }: ChatProps) => {
     setMessages([]); // 🐛 (API?) Fetch Live chat message
   };
 
-  const createMessage = (message: string) => {
+  const createMessage = (text: string) => {
     // 🐛 (API) Create message
     // Providing info : message (string)
-    const dummyMessageObj = {
-      id: 999,
-      userName: 'MyName',
-      message,
-      time: '00:00',
-      isMy: true
-    };
 
     // Send message
     socket?.emit(
-      'ChatTextMessage',
+      'LiveChatTextMessage',
       JSON.stringify({
-        classUuid: room,
-        currentUserName,
-        textMessage: message
+        classUuid,
+        lectureId,
+        text
       })
     );
 
@@ -156,9 +157,9 @@ const Chat = ({ hasHeader, room, customHeader = '' }: ChatProps) => {
         </Header>
       )}
       <Flex w="280px" overflowY="auto" pb={3} pt={3} flexDir="column" h="full">
-        {messages.map(({ userName, message, time, id, isMy }) => (
+        {messages.map(({ userName, message, time, messageId, isMy }) => (
           <ChatMessage
-            key={id}
+            key={messageId}
             userName={userName}
             message={message}
             time={time}

--- a/client/src/components/chat.tsx
+++ b/client/src/components/chat.tsx
@@ -51,7 +51,7 @@ const Chat = ({
     chatMode: ChatMode.Live
   });
   const currentMarkerId = useRef<number>(-1);
-  const { id: myId, userName: myName } = useMe();
+  const { id: myId } = useMe();
 
   // Set Chat header title
   const pickHeader = (chatStat: ChatStatus) => {
@@ -78,29 +78,29 @@ const Chat = ({
       (markerId: number, markerType: MarkerType) => {
         // 🐛 (API) Fetch timeMarker thread messages
         currentMarkerId.current = markerId;
-        // setChatMode(markerType as number);
-        // setMessages(dummyMessages.slice(markerId * 3, markerId * 3 + 3));
       }
     );
 
     // Live chat event - get live chat message
     socket?.on('LiveChatTextMessage', ({ message, status }) => {
-      const {
-        dateStr,
-        senderId,
-        senderName,
-        text,
-        messageId
-      }: TextMessageResponse = message;
-      const dateObj = new Date(dateStr);
-      const messageObj: Message = {
-        messageId,
-        userName: senderName,
-        message: text,
-        time: `${dateObj.getHours()}:${dateObj.getMinutes()}`,
-        isMy: senderId === myId
-      };
-      setMessages(arr => [...arr, messageObj]);
+      if (status === 200) {
+        const {
+          dateStr,
+          senderId,
+          senderName,
+          text,
+          messageId
+        }: TextMessageResponse = message;
+        const dateObj = new Date(dateStr);
+        const messageObj: Message = {
+          messageId,
+          userName: senderName,
+          message: text,
+          time: `${dateObj.getHours()}:${dateObj.getMinutes()}`,
+          isMy: senderId === myId
+        };
+        setMessages(arr => [...arr, messageObj]);
+      }
     });
   }, [connected]);
 

--- a/client/src/context/user/userContext.tsx
+++ b/client/src/context/user/userContext.tsx
@@ -4,11 +4,13 @@ import { UserLoadStatus } from '../../types';
 interface UserContextInterface {
   userName: string;
   status: UserLoadStatus;
+  id: number;
 }
 
 const UserContext = createContext<UserContextInterface>({
   userName: '',
-  status: UserLoadStatus.LOADED
+  status: UserLoadStatus.LOADED,
+  id: -1
 });
 
 export default UserContext;

--- a/client/src/context/user/userProvider.tsx
+++ b/client/src/context/user/userProvider.tsx
@@ -6,6 +6,7 @@ import UserContext from './userContext';
 const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
   const [userName, setUserName] = useState('');
   const [status, setUserStatus] = useState(UserLoadStatus.LOADING);
+  const [id, setId] = useState(-1);
 
   useEffect(() => {
     if (status === UserLoadStatus.LOADING) {
@@ -19,6 +20,7 @@ const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
           } else if (r.status === 200) {
             console.log('Logged IN');
             setUserName(r.userName);
+            setId(r.id);
             setUserStatus(UserLoadStatus.LOADED);
           }
         })
@@ -27,7 +29,7 @@ const UserProvider = ({ children }: React.PropsWithChildren<unknown>) => {
   }, []);
 
   return (
-    <UserContext.Provider value={{ userName, status }}>
+    <UserContext.Provider value={{ userName, status, id }}>
       {children}
     </UserContext.Provider>
   );

--- a/client/src/hooks/useMe.tsx
+++ b/client/src/hooks/useMe.tsx
@@ -2,9 +2,9 @@ import { useContext } from 'react';
 import UserContext from '../context/user/userContext';
 
 const useMe = () => {
-  const { status, userName } = useContext(UserContext);
+  const { status, userName, id } = useContext(UserContext);
 
-  return { status, userName };
+  return { status, userName, id };
 };
 
 export default useMe;

--- a/client/src/pages/chatTestPage.tsx
+++ b/client/src/pages/chatTestPage.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import Chat from '../components/chat';
-
-const ChatTestPage = () => {
-  return <Chat room="" hasHeader />;
-};
-
-export default ChatTestPage;

--- a/client/src/pages/classPage.tsx
+++ b/client/src/pages/classPage.tsx
@@ -76,7 +76,7 @@ const ClassPage = () => {
             <Button>Create new lecture</Button>
           </Link>
         </Box>
-        <Chat room={classUuid!} hasHeader />
+        {/* <Chat classUuid={classUuid!} hasHeader /> */}
       </Flex>
     </>
   );

--- a/client/src/pages/lecturePage.tsx
+++ b/client/src/pages/lecturePage.tsx
@@ -55,7 +55,7 @@ const LecturePage = () => {
             height="100%"
           />
         </Box>
-        <Chat room={/* 🐛 lectureId */ classUuid!} hasHeader />
+        <Chat classUuid={classUuid!} lectureId={parsedLectureId} hasHeader />
       </Flex>
     </>
   );

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -36,8 +36,19 @@ export enum MarkerType {
   DISCUSSION = 'Discussion'
 }
 
-export interface Message {
-  id: number;
+export interface MessageResponse {
+  messageId: number;
+  senderId: number;
+  senderName: string;
+  dateStr: string;
+}
+
+export interface TextMessageResponse extends MessageResponse {
+  text: string;
+}
+
+export interface AudioMessageResponse extends MessageResponse {
+  url: string;
 }
 
 export interface Marker {
@@ -45,5 +56,5 @@ export interface Marker {
   markerType: MarkerType;
   time: number;
   videoIndex: number;
-  messages: Message[];
+  messages: MessageResponse[];
 }

--- a/server/src/ioHandler/chatProtocols.ts
+++ b/server/src/ioHandler/chatProtocols.ts
@@ -4,21 +4,23 @@ import { CustomSocket } from '../types';
 const OnLiveChatTextMessage =
   (socket: CustomSocket, classManager: ClassManager) =>
   async (request: string) => {
-    const { classUuid, currentUserName, textMessage, lectureId } =
-      JSON.parse(request);
+    const { classUuid, text, lectureId } = JSON.parse(request);
     const cls = await classManager.getOrCreateClass(classUuid);
     const lecture = cls.getLectureById(lectureId);
-    const payload = {
+    const { userName, id } = socket.request.user!;
+
+    const message = {
       dateStr: new Date().toISOString(),
-      textMessage,
-      chatUserName: currentUserName
+      text,
+      senderName: userName,
+      senderId: id
     };
     socket.emit('LiveChatTextMessage', {
-      message: { ...payload, isMy: true },
+      message,
       status: 200
     });
     socket.to(lecture.getSocketRoomName()).emit('LiveChatTextMessage', {
-      message: { ...payload, isMy: false },
+      message,
       status: 200
     });
   };

--- a/server/src/ioHandler/classProtocols.ts
+++ b/server/src/ioHandler/classProtocols.ts
@@ -57,23 +57,19 @@ const OnJoinLecture =
   async (request: string) => {
     const { classUuid, lectureId } = JSON.parse(request);
     const cls: Class = await classManager.getOrCreateClass(classUuid);
-    const lecture: Lecture | undefined = cls.getLectureById(lectureId);
-
-    let status: number = 200;
-    if (!lecture) {
-      Logger.error(
-        `Lecture#${lectureId} not found in class ${cls.title} with id='${cls.uuid}'`
-      );
-      status = 404;
-    }
+    const lecture: Lecture = cls.getLectureById(lectureId);
 
     lecture.addParticipant(cls.getMemberById(socket.request.user!.id));
     Logger.debug(`Join Lecture:\nLecture: ${JSON.stringify(lecture, null, 2)}`);
     socket.join(lecture.getSocketRoomName());
     socket
       .to(lecture.getSocketRoomName())
-      .emit('JoinLecture', { user: socket.request.user, lecture, status });
-    socket.emit('JoinLecture', { user: socket.request.user, lecture, status });
+      .emit('JoinLecture', { user: socket.request.user, lecture, status: 200 });
+    socket.emit('JoinLecture', {
+      user: socket.request.user,
+      lecture,
+      status: 200
+    });
   };
 
 const OnGetClassMembers =

--- a/server/src/routes/meRoute/index.ts
+++ b/server/src/routes/meRoute/index.ts
@@ -7,6 +7,7 @@ export default (app: Router) => {
 
   meRouter.get('/', authenticateUser, (req, res) => {
     const userName = req.user?.userName;
-    res.json({ userName, status: 200 });
+    const id = req.user?.id;
+    res.json({ userName, id, status: 200 });
   });
 };


### PR DESCRIPTION
## 개요

1. /me api 수정 & UserContext 수정
2. LiveChatTextMessage 프로토콜 수정
3. Chat Componet 수정

## 세부 사항

1. /me api 수정 & UserContext 수정

로컬에서 받은 메세지가 나의 메세지인지, 다른 사람이 보낸 메세지인지 확인하려면 중복될 수 있는 userName보다 user id가 더 적합하다고 판단해서 서버에서 유저 id를 받아온 후 컨텍스트에 저장하도록 하였습니다.

- e2171ed7266d91a79349e6eff4c26a9a64e4a8ee: #109/Fix meRoute to send user id
- fe91339cb32a9e5e97f41e6e6db6bd3c4e41dd1f: #109/Update UserContext to provide id

2. LiveChatTextMessage 프로토콜 수정

**Request**
```js
{ 
  classUuid: string, 
  lectureId: number, 
  text: string, 
}
```

**Response(if succeed)**
```js
{
  message: TextMessageResponse // client/src/types/index.ts
  status: 200
}
```

- fe93c9aa86b418a2e69c27e67fd037992996984c: #109/Change LiveChat Handler Req/Res Type

3. Chat Componet 수정

변경된 API에 맞게 채팅 받도록 수정

- 6cdc2ca9f703b9f1bd44199788fedcf5c5e86191: #109/Create MessageResponse Type
- 6b897ffc5d980843ca3025425069a8a971f1b374: #109/Sync Chat Component to LiveChat API

## TODO
- [ ] Chatting Context 만들어서 컴포넌트와 로직 분리 (지금 너무 복잡함)
