### PR TITLE
Papago#40 - (FrontEnd) Language context

### DIFF
--- a/client/src/components/leftmenu/leftmenu.tsx
+++ b/client/src/components/leftmenu/leftmenu.tsx
@@ -24,6 +24,7 @@ import {
 import LeftMenuTab from './leftmenutab';
 import Header from '../common/Header';
 import LangContext from '../../context/language/languageContext';
+import { LanguageType } from '../../types';
 
 const GlobeIcon = createIcon({
   displayName: 'GlobeIcon',
@@ -121,7 +122,7 @@ const LeftMenu = ({ className, menus }: LeftMenuProps) => {
                         colorScheme="green"
                         marginRight="2px"
                         onClick={() => {
-                          setLanguage('en');
+                          setLanguage(LanguageType.EN);
                           onClose();
                         }}
                       >
@@ -130,7 +131,7 @@ const LeftMenu = ({ className, menus }: LeftMenuProps) => {
                       <Button
                         colorScheme="blue"
                         onClick={() => {
-                          setLanguage('ko');
+                          setLanguage(LanguageType.KO);
                           onClose();
                         }}
                       >

--- a/client/src/components/leftmenu/leftmenu.tsx
+++ b/client/src/components/leftmenu/leftmenu.tsx
@@ -1,4 +1,10 @@
-import { ChevronRightIcon, CloseIcon, SettingsIcon } from '@chakra-ui/icons';
+import React, { useContext } from 'react';
+import {
+  ChevronRightIcon,
+  CloseIcon,
+  SettingsIcon,
+  createIcon
+} from '@chakra-ui/icons';
 import {
   Button,
   Popover,
@@ -7,15 +13,31 @@ import {
   PopoverArrow,
   PopoverBody,
   Box,
+  Button,
   Flex,
   StackDivider,
   VStack,
   IconButton,
   Spacer
 } from '@chakra-ui/react';
-import React from 'react';
+
 import LeftMenuTab from './leftmenutab';
 import Header from '../common/Header';
+import LangContext from '../../context/language/languageContext';
+
+const GlobeIcon = createIcon({
+  displayName: 'GlobeIcon',
+  path: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+    >
+      <path d="M24 24h-2.784l-1.07-3h-4.875l-1.077 3h-2.697l4.941-13h2.604l4.958 13zm-4.573-5.069l-1.705-4.903-1.712 4.903h3.417zm-9.252-12.804c.126-.486.201-.852.271-1.212l-2.199-.428c-.036.185-.102.533-.22 1-.742-.109-1.532-.122-2.332-.041.019-.537.052-1.063.098-1.569h2.456v-2.083h-2.161c.106-.531.198-.849.288-1.149l-2.147-.645c-.158.526-.29 1.042-.422 1.794h-2.451v2.083h2.184c-.058.673-.093 1.371-.103 2.077-2.413.886-3.437 2.575-3.437 4.107 0 1.809 1.427 3.399 3.684 3.194 2.802-.255 4.673-2.371 5.77-4.974 1.134.654 1.608 1.753 1.181 2.771-.396.941-1.561 1.838-3.785 1.792v2.242c2.469.038 4.898-.899 5.85-3.166.93-2.214-.132-4.635-2.525-5.793zm-2.892 1.531c-.349.774-.809 1.544-1.395 2.15-.09-.646-.151-1.353-.184-2.108.533-.07 1.072-.083 1.579-.042zm-3.788.724c.062.947.169 1.818.317 2.596-1.996.365-2.076-1.603-.317-2.596zm11.236-1.745l-2.075-5.533 5.414-1.104-.976 1.868c2.999 2.418 4.116 5.645 4.532 8.132-1.736-2.913-3.826-4.478-5.885-5.321l-1.01 1.958zm-7.895 10.781l1.985 5.566-5.43 1.016 1.006-1.852c-2.96-2.465-4.021-5.654-4.397-8.148 1.689 2.94 3.749 4.483 5.794 5.36l1.042-1.942zm10.795-6.029" />
+    </svg>
+  )
+});
 
 export interface TabContent {
   tabName: string;
@@ -31,7 +53,9 @@ interface LeftMenuProps {
   menus: Menu[];
 }
 
-const LeftMenu = ({ menus }: LeftMenuProps) => {
+const LeftMenu = ({ className, menus }: LeftMenuProps) => {
+  const { language, setLanguage } = useContext(LangContext);
+
   return (
     <Flex w="190px" h="100vh" flexDir="column">
       <Flex overflowX="hidden" overflowY="auto" flexDir="column">
@@ -79,6 +103,46 @@ const LeftMenu = ({ menus }: LeftMenuProps) => {
             aria-label="Settings"
             m={0.5}
           />
+          <Popover placement="top-start">
+            {({ onClose }) => (
+              <>
+                <PopoverTrigger>
+                  <IconButton
+                    size="sm"
+                    icon={<GlobeIcon />}
+                    aria-label="Settings"
+                    m={0.5}
+                  />
+                </PopoverTrigger>
+                <Portal>
+                  <PopoverContent w="165px" h="60px">
+                    <PopoverBody>
+                      <Button
+                        colorScheme="green"
+                        marginRight="2px"
+                        onClick={() => {
+                          setLanguage('en');
+                          onClose();
+                        }}
+                      >
+                        EN
+                      </Button>
+                      <Button
+                        colorScheme="blue"
+                        onClick={() => {
+                          setLanguage('ko');
+                          onClose();
+                        }}
+                      >
+                        한글
+                      </Button>
+                      <PopoverCloseButton />
+                    </PopoverBody>
+                  </PopoverContent>
+                </Portal>
+              </>
+            )}
+          </Popover>
         </Box>
       </Flex>
     </Flex>

--- a/client/src/components/leftmenu/leftmenu.tsx
+++ b/client/src/components/leftmenu/leftmenu.tsx
@@ -6,25 +6,26 @@ import {
   createIcon
 } from '@chakra-ui/icons';
 import {
-  Button,
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-  PopoverArrow,
-  PopoverBody,
   Box,
   Button,
   Flex,
   StackDivider,
   VStack,
   IconButton,
+  Portal,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverArrow,
   Spacer
 } from '@chakra-ui/react';
 
+import { LanguageType } from '../../types';
 import LeftMenuTab from './leftmenutab';
 import Header from '../common/Header';
 import LangContext from '../../context/language/languageContext';
-import { LanguageType } from '../../types';
 
 const GlobeIcon = createIcon({
   displayName: 'GlobeIcon',
@@ -54,7 +55,7 @@ interface LeftMenuProps {
   menus: Menu[];
 }
 
-const LeftMenu = ({ className, menus }: LeftMenuProps) => {
+const LeftMenu = ({ menus }: LeftMenuProps) => {
   const { language, setLanguage } = useContext(LangContext);
 
   return (

--- a/client/src/context/language/languageContext.tsx
+++ b/client/src/context/language/languageContext.tsx
@@ -1,12 +1,13 @@
 import { createContext } from 'react';
+import { LanguageType } from '../../types';
 
 interface langContextInterface {
-  language: string;
-  setLanguage: (language: string) => void;
+  language: LanguageType;
+  setLanguage: (language: LanguageType) => void;
 }
 
 const langContext = createContext<langContextInterface>({
-  language: 'ko',
+  language: LanguageType.KO,
   setLanguage: () => null
 });
 

--- a/client/src/context/language/languageContext.tsx
+++ b/client/src/context/language/languageContext.tsx
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+interface langContextInterface {
+  language: string;
+  setLanguage: (language: string) => void;
+}
+
+const langContext = createContext<langContextInterface>({
+  language: 'ko',
+  setLanguage: () => null
+});
+
+export default langContext;

--- a/client/src/context/language/languageProvider.tsx
+++ b/client/src/context/language/languageProvider.tsx
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+
+import langContext from './languageContext';
+
+const langProvider = ({ children }: React.PropsWithChildren<unknown>) => {
+  const [language, setLanguage] = useState<string>('ko');
+
+  return (
+    <langContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </langContext.Provider>
+  );
+};
+
+export default langProvider;

--- a/client/src/context/language/languageProvider.tsx
+++ b/client/src/context/language/languageProvider.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-
 import langContext from './languageContext';
+import { LanguageType } from '../../types';
 
 const langProvider = ({ children }: React.PropsWithChildren<unknown>) => {
-  const [language, setLanguage] = useState<string>('ko');
+  const [language, setLanguage] = useState<LanguageType>(LanguageType.KO);
 
   return (
     <langContext.Provider value={{ language, setLanguage }}>

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,12 +6,15 @@ import App from './App';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 import UserProvider from './context/user/userProvider';
+import LangProvider from './context/language/languageProvider';
 
 ReactDOM.render(
   <React.StrictMode>
     <ChakraProvider>
       <UserProvider>
-        <App />
+        <LangProvider>
+          <App />
+        </LangProvider>
       </UserProvider>
     </ChakraProvider>
   </React.StrictMode>,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -58,3 +58,8 @@ export interface Marker {
   videoIndex: number;
   messages: MessageResponse[];
 }
+
+export enum LanguageType {
+  EN,
+  KO
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,8 +13,12 @@ SERVER_PORT=5000
 # Secret Key for session
 SESSION_SECRET=m!y@s#e$c%r%e^t
 
-# OAuth Secrets
 # Naver
+# OAuth Secrets
 NAVER_AUTH_CLIENT_ID='client id'
 NAVER_AUTH_CLIENT_SECRET='client secret'
 NAVER_AUTH_CALLBACK_URL='callback url'
+
+# Papago Secrets
+X-NAVER-CLIENT-ID='client id'
+X-NAVER-CLIENT-SECRET='client secret'

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
+    "axios": "^0.24.0",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",

--- a/server/src/externalAPI/PapagoAPI.ts
+++ b/server/src/externalAPI/PapagoAPI.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const callPapagoTranslation = (
+  source: string,
+  target: string,
+  text: string
+) => {
+  let translatedString: string = '';
+  let status;
+  axios
+    .request({
+      url: 'https://openapi.naver.com/v1/papago/n2mt',
+      method: 'POST',
+      data: {
+        source,
+        target,
+        text
+      },
+      headers: {
+        'Content-type': 'application/json; charset=UTF-8',
+        'X-Naver-Client-Id': process.env.NAVER_PAPAGO_CLIENT_ID!,
+        'X-Naver-Client-Secret': process.env.NAVER_PAPAGO_CLIENT_SECRET!
+      }
+    })
+    .then(res => {
+      status = 200;
+      translatedString = res.data;
+    })
+    .catch(err => {
+      status = 400; // FIX
+      if (err.response) console.log('res error : ', err.response.data);
+      if (err.request) console.log('req error : ', err.request.data);
+    });
+
+  return { translatedString, status };
+};
+
+export default callPapagoTranslation;


### PR DESCRIPTION
## 개요
채팅 내용을 Papago로 번역하기 전, 사용자가 '목적 언어(target language)'를 선택할 수 있도록 Language context 제작.

### 1. LeftMenu에 Language context 변경 버튼 생성

🔥 근데 처음 서비스 사용하는 사용자들이 한 눈에 '이게 뭐하는 버튼이지?' 라고 알아볼 수 있을 것 같진 않음

![image](https://user-images.githubusercontent.com/39735858/144693121-e8ed7ce5-7213-4be8-8ad4-ac546f0d372e.png)

### 2. Language context 제작

`client/src/context/langugage`의 `languageContext`와
```tsx
interface langContextInterface {
  language: LanguageType;
  setLanguage: (language: LanguageType) => void;
}

const langContext = createContext<langContextInterface>({
  language: LanguageType.KO,
  setLanguage: () => null
});
```

 `languageProvider`
```tsx
const langProvider = ({ children }: React.PropsWithChildren<unknown>) => {
  const [language, setLanguage] = useState<LanguageType>(LanguageType.KO);

  return (
    <langContext.Provider value={{ language, setLanguage }}>
      {children}
    </langContext.Provider>
  );
};

```


`setLanguage` 함수를 Context를 통해 children으로 넘겨줘서, 언제든지 language context 변경 가능하도록.