### PR TITLE
Get active user protocol#127

### DIFF
--- a/client/src/pages/lecturePage.tsx
+++ b/client/src/pages/lecturePage.tsx
@@ -50,9 +50,6 @@ const LecturePage = () => {
       });
 
       setVideoArr(videoList);
-
-      const payload = { classUuid, lectureId };
-      socket?.emit('GetActiveLectureMember', payload);
     });
   }, [lecture]);
 
@@ -67,10 +64,13 @@ const LecturePage = () => {
           type: TabType.USER,
           userId: user.id
         };
+
         setMemberArr(arr => [...arr, newUser]);
+        const payload = { classUuid, lectureId: parsedLectureId };
+        socket?.emit('GetActiveLectureMember', payload);
       }
     });
-    const payload = JSON.stringify({ classUuid, lectureId: parsedLectureId });
+    const payload = { classUuid, lectureId: parsedLectureId };
     socket?.emit('JoinLecture', payload);
 
     // get members participating in the lecture

--- a/server/src/data/class.ts
+++ b/server/src/data/class.ts
@@ -4,6 +4,7 @@ import Member from './member';
 
 import LectureEntity from '../entity/lectureEntity';
 import Lecture from './lecture';
+import Logger from '../loader/logger';
 
 class Class {
   public readonly uuid: classUuid;
@@ -45,10 +46,12 @@ class Class {
 
   public exitUser(userId: number): boolean {
     const member = this.getMemberById(userId);
-
+    Logger.info(`User ${member.userName} Exit Class ${this.title}`);
     if (!member) {
       return false;
     }
+    this.lectures.forEach(lecture => lecture.exitParticipant(userId));
+
     member?.setConnectStatus(false);
 
     return true;
@@ -90,10 +93,6 @@ class Class {
 
     return newLecture;
   }
-
-  // public joinLecture(lectureId: number): Lecture | undefined {
-  //   return this.availableLectures.find(({ id }) => id === lectureId);
-  // }
 }
 
 export default Class;

--- a/server/src/data/lecture.ts
+++ b/server/src/data/lecture.ts
@@ -1,5 +1,6 @@
 import LectureEntity from '../entity/lectureEntity';
 import MarkerEntity from '../entity/markerEntity';
+import Logger from '../loader/logger';
 // import { classUuid } from '../types';
 import Marker from './marker';
 import Member from './member';
@@ -82,9 +83,28 @@ class Lecture {
     return `lecture_${this.id}`;
   }
 
-  public addParticipant(member: Member) {
-    this.participants.push(member);
-    member.setParticipatingLecture(this.id);
+  public addParticipant(member: Member): boolean {
+    if (!this.participants.find(({ userId }) => userId === member.userId)) {
+      this.participants.push(member);
+      Logger.info(`User ${member?.userName} Join Class ${this.lectureName}`);
+      member.setParticipatingLecture(this.id);
+      return true;
+    }
+    Logger.info(
+      `User ${member?.userName} is Already in Class ${this.lectureName}`
+    );
+    return false;
+  }
+
+  public exitParticipant(id: number): Member | undefined {
+    const member = this.participants.find(({ userId }) => id === userId);
+    if (member) {
+      Logger.info(`User ${member?.userName} Exit Class ${this.lectureName}`);
+      this.participants = this.participants.filter(
+        ({ userId }) => id !== userId
+      );
+    }
+    return member;
   }
 
   public async getEntity(): Promise<LectureEntity> {
@@ -93,6 +113,10 @@ class Lecture {
       throw new Error('No Such Lecture');
     }
     return entity;
+  }
+
+  public getParticipants(): Member[] {
+    return this.participants;
   }
 }
 

--- a/server/src/ioHandler/classProtocols.ts
+++ b/server/src/ioHandler/classProtocols.ts
@@ -58,26 +58,6 @@ const OnCreateLecture =
     socket.emit('CreateLecture', { lecture, status: 200 });
   };
 
-const OnJoinLecture =
-  (socket: CustomSocket, classManager: ClassManager) =>
-  async (request: string) => {
-    const { classUuid, lectureId } = JSON.parse(request);
-    const cls: Class = await classManager.getOrCreateClass(classUuid);
-    const lecture: Lecture = cls.getLectureById(lectureId);
-
-    lecture.addParticipant(cls.getMemberById(socket.request.user!.id));
-    Logger.debug(`Join Lecture:\nLecture: ${JSON.stringify(lecture, null, 2)}`);
-    socket.join(lecture.getSocketRoomName());
-    socket
-      .to(lecture.getSocketRoomName())
-      .emit('JoinLecture', { user: socket.request.user, lecture, status: 200 });
-    socket.emit('JoinLecture', {
-      user: socket.request.user,
-      lecture,
-      status: 200
-    });
-  };
-
 const OnGetClassMembers =
   (socket: CustomSocket, classManager: ClassManager) =>
   async (request: string) => {
@@ -92,6 +72,5 @@ export default {
   OnJoinClass,
   OnGetLectures,
   OnCreateLecture,
-  OnJoinLecture,
   OnGetClassMembers
 };

--- a/server/src/ioHandler/index.ts
+++ b/server/src/ioHandler/index.ts
@@ -6,6 +6,7 @@ import ChatProtocols from './chatProtocols';
 import ClassProtocols from './classProtocols';
 import YoutubeProtocols from './youtubeProtocols';
 import MarkerProtocols from './markerProtocols';
+import LectureProtocols from './lectureProtocols';
 
 export default (io: SocketIOServer, classManager: ClassManager) => {
   io.on('connection', (socket: CustomSocket) => {
@@ -59,7 +60,6 @@ export default (io: SocketIOServer, classManager: ClassManager) => {
     );
 
     // In Class API
-    // lecture related
     socket.on(
       'GetLectures',
       ClassProtocols.OnGetLectures(socket, classManager)
@@ -67,10 +67,6 @@ export default (io: SocketIOServer, classManager: ClassManager) => {
     socket.on(
       'CreateLecture',
       ClassProtocols.OnCreateLecture(socket, classManager)
-    );
-    socket.on(
-      'JoinLecture',
-      ClassProtocols.OnJoinLecture(socket, classManager)
     );
     socket.on(
       'GetClassMembers',
@@ -97,6 +93,16 @@ export default (io: SocketIOServer, classManager: ClassManager) => {
     socket.on(
       'LiveChatAudioMessage',
       ChatProtocols.OnLiveChatAudioMessage(socket, classManager)
+    );
+
+    // Lecture Protocols
+    socket.on(
+      'GetActiveLectureMember',
+      LectureProtocols.GetActiveLectureMember(socket, classManager)
+    );
+    socket.on(
+      'JoinLecture',
+      LectureProtocols.OnJoinLecture(socket, classManager)
     );
   });
 };

--- a/server/src/ioHandler/lectureProtocols.ts
+++ b/server/src/ioHandler/lectureProtocols.ts
@@ -1,0 +1,63 @@
+import Class from '../data/class';
+import ClassManager from '../data/classManager';
+import Lecture from '../data/lecture';
+import Logger from '../loader/logger';
+import { CustomSocket, InLectureRequestInterface } from '../types';
+
+const OnJoinLecture =
+  (socket: CustomSocket, classManager: ClassManager) =>
+  async ({ classUuid, lectureId }: InLectureRequestInterface) => {
+    const cls: Class = await classManager.getOrCreateClass(classUuid);
+    const lecture: Lecture = cls.getLectureById(lectureId);
+
+    if (lecture.addParticipant(cls.getMemberById(socket.request.user!.id))) {
+      Logger.debug(
+        `Join Lecture:\nLecture: ${JSON.stringify(lecture, null, 2)}`
+      );
+      socket.join(lecture.getSocketRoomName());
+      socket.to(lecture.getSocketRoomName()).emit('JoinLecture', {
+        user: socket.request.user,
+        lecture,
+        status: 200
+      });
+      socket.emit('JoinLecture', {
+        user: socket.request.user,
+        lecture,
+        status: 200
+      });
+    } else {
+      socket.emit('JoinLecture', {
+        user: socket.request.user,
+        lecture,
+        status: 200
+      });
+    }
+  };
+
+const OnExitLecture =
+  (socket: CustomSocket, classManager: ClassManager) =>
+  async ({ classUuid, lectureId }: InLectureRequestInterface) => {
+    const cls = await classManager.getOrCreateClass(classUuid);
+    const lecture = cls.getLectureById(lectureId);
+
+    const member = lecture.exitParticipant(socket.request.user?.id!);
+
+    socket.to(lecture.getSocketRoomName()).emit('GetActiveLectureMember', {
+      member,
+      status: 200
+    });
+  };
+
+const GetActiveLectureMember =
+  (socket: CustomSocket, classManager: ClassManager) =>
+  async ({ classUuid, lectureId }: InLectureRequestInterface) => {
+    const cls = await classManager.getOrCreateClass(classUuid);
+    const lecture = cls.getLectureById(lectureId);
+
+    socket.emit('GetActiveLectureMember', {
+      members: lecture.getParticipants(),
+      status: 200
+    });
+  };
+
+export default { GetActiveLectureMember, OnJoinLecture, OnExitLecture };


### PR DESCRIPTION
## 개요

1. Lecture에 참여중인 참가자들을 가져오는 GetActiveUser 프로토콜을 구현했습니다.
2. 유저의 입장, 퇴장 로직을 일부 수정하고, ExitLecture protocol을 구현했습니다..

## 세부 설명

1. GetActiveUser

렉쳐에 참여중인 유저들의 정보를 불러옵니다.
**Request**
```js
InLectureRequestInterface { 
  classUuid: string, 
  lectureId: number
}
```

**Response(if succeed)**
```js
{
  members: Member[],
  status: 200
}
```

2. ExitLecture

렉쳐에서 나가고, 렉쳐 참가자들에게 나간 참여자의 정보를 broadcast합니다

**Request**
```js
InLectureRequestInterface { 
  classUuid: string, 
  lectureId: number
}
```

**Response(if succeed)**
```js
{
  member: Member,
  status: 200
}
```


## TODO & Problems

- 유저가 브라우저 뒤로가기를 하거나 exit lecture을 할 경우 서버로 ExitLecture을 emit해야함