### PR TITLE
Auto translation api#119

### DIFF
--- a/server/src/externalAPI/PapagoAPI.ts
+++ b/server/src/externalAPI/PapagoAPI.ts
@@ -1,41 +1,57 @@
 import axios from 'axios';
-import * as dotenv from 'dotenv';
+import config from '../config';
+import {
+  Language,
+  PapagoLanguageDetectionResponse,
+  PapagoTranslateResponse
+} from '../types';
 
-dotenv.config();
+const translate = async (source: Language, target: Language, text: string) => {
+  if (source === target) return { result: text, status: 201 };
 
-const callPapagoTranslation = (
-  source: string,
-  target: string,
-  text: string
-) => {
-  let translatedString: string = '';
-  let status;
-  axios
-    .request({
-      url: 'https://openapi.naver.com/v1/papago/n2mt',
-      method: 'POST',
-      data: {
-        source,
-        target,
-        text
-      },
-      headers: {
-        'Content-type': 'application/json; charset=UTF-8',
-        'X-Naver-Client-Id': process.env.NAVER_PAPAGO_CLIENT_ID!,
-        'X-Naver-Client-Secret': process.env.NAVER_PAPAGO_CLIENT_SECRET!
-      }
-    })
-    .then(res => {
-      status = 200;
-      translatedString = res.data;
-    })
-    .catch(err => {
-      status = 400; // FIX
-      if (err.response) console.log('res error : ', err.response.data);
-      if (err.request) console.log('req error : ', err.request.data);
-    });
+  const { data, status } = await axios.request({
+    url: 'https://openapi.naver.com/v1/papago/n2mt',
+    method: 'POST',
+    data: {
+      source,
+      target,
+      text
+    },
+    headers: {
+      'Content-type': 'application/json; charset=UTF-8',
+      'X-Naver-Client-Id': config.auth.naver.clientId,
+      'X-Naver-Client-Secret': config.auth.naver.clientSecret
+    }
+  });
 
-  return { translatedString, status };
+  const {
+    message: { result: translatedText }
+  }: PapagoTranslateResponse = data;
+
+  return { result: translatedText, status };
 };
 
-export default callPapagoTranslation;
+// curl "https://openapi.naver.com/v1/papago/detectLangs" \
+//     -d "query=만나서 반갑습니다." \
+//     -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" \
+//     -H "X-Naver-Client-Id: MsZ7xuiNrx_i7M53OKC7" \
+//     -H "X-Naver-Client-Secret: ck0NrxrKXT" -v
+
+const detectLanguage = async (query: string) => {
+  const { data } = await axios.request({
+    url: 'https://openapi.naver.com/v1/papago/detectLangs',
+    method: 'POST',
+    data: { query },
+    headers: {
+      'Content-type': 'application/json; charset=UTF-8',
+      'X-Naver-Client-Id': config.auth.naver.clientId,
+      'X-Naver-Client-Secret': config.auth.naver.clientSecret
+    }
+  });
+
+  const { langCode }: PapagoLanguageDetectionResponse = data;
+
+  return { src: langCode };
+};
+
+export { detectLanguage, translate };

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import auth from './authRoute';
 import meRoute from './meRoute';
 import lobbyRoute from './lobbyRoute';
+import translateRoute from './translateRoute';
 
 export default () => {
   const route = Router();
@@ -10,6 +11,7 @@ export default () => {
   auth(route);
   meRoute(route);
   lobbyRoute(route);
+  translateRoute(route);
 
   return route;
 };

--- a/server/src/routes/translateRoute/index.ts
+++ b/server/src/routes/translateRoute/index.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { detectLanguage, translate } from '../../externalAPI/PapagoAPI';
+import Logger from '../../loader/logger';
+import { TranslateRequestInterface } from '../../types';
+
+export default (app: Router) => {
+  const translateRouter = Router();
+  app.use('/translate', translateRouter);
+
+  translateRouter.post('/', async (req, res) => {
+    try {
+      const { translateArray, target }: TranslateRequestInterface = req.body;
+
+      const translated = await Promise.all(
+        translateArray.map(async (text: string) => {
+          const { src } = await detectLanguage(text);
+          return translate(src, target, text);
+        })
+      );
+
+      res.json({ translated });
+    } catch (e) {
+      Logger.error(e);
+    }
+  });
+};

--- a/server/src/routes/translateRoute/index.ts
+++ b/server/src/routes/translateRoute/index.ts
@@ -1,13 +1,14 @@
 import { Router } from 'express';
 import { detectLanguage, translate } from '../../externalAPI/PapagoAPI';
 import Logger from '../../loader/logger';
+import { authenticateUser } from '../../passport';
 import { TranslateRequestInterface } from '../../types';
 
 export default (app: Router) => {
   const translateRouter = Router();
   app.use('/translate', translateRouter);
 
-  translateRouter.post('/', async (req, res) => {
+  translateRouter.post('/', authenticateUser, async (req, res) => {
     try {
       const { translateArray, target }: TranslateRequestInterface = req.body;
 

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -7,8 +7,8 @@ type uuid = string;
 export type classUuid = uuid;
 
 export enum Language {
-  KO = 'KO',
-  EN = 'EN'
+  KO = 'ko',
+  EN = 'en'
 }
 
 export interface CustomSocket extends Socket {
@@ -43,4 +43,28 @@ export interface InLectureRequestInterface extends InClassRequestInterface {
 export interface LiveChatAudioMessageInterface
   extends InLectureRequestInterface {
   arrayBuffer: ArrayBuffer;
+}
+
+export interface TranslateRequestInterface {
+  translateArray: string[];
+  target: Language;
+}
+
+export interface PapagoTranslateResponse {
+  message: {
+    '@type': string;
+    '@service': string;
+    '@version': string;
+    result: {
+      srcLangType: Language;
+      tarLangType: Language;
+      translatedText: string;
+      engineType: string;
+      pivot: any;
+    };
+  };
+}
+
+export interface PapagoLanguageDetectionResponse {
+  langCode: Language;
 }


### PR DESCRIPTION
## 개요

자동 번역 api를 제작했습니다.

## Usage

**Request**
```ts
interface TranslateRequestInterface {
  translateArray: string[];
  target: Language;   // 번역 타겟 언어
}
```

**Response (if success)**
```ts
{
  translated: { result:string, status: 200 | 201 }[],  // 번역 했으면 200, 번역 안했으면 201
  status: 200
}
```

## 세부 설명

Papago api를 이용해서 translation api를 제작했습니다

번역을 원하는 string array와 목적 언어로 request를 하면, language detection api를 이용해서 source text의 언어를 감지하고, 번역 api를 이용해서 타겟 언어로 번역합니다. 만약 source language와 target language가 같으면, 번역 api를 호출하지 않고 status code 201과 원본 그대로인 문자열을 반환하도록 했습니다.

